### PR TITLE
Quotation marks correctly

### DIFF
--- a/xosview.1
+++ b/xosview.1
@@ -323,9 +323,9 @@ Equivalent to \-irqrate and +irqrate.
 .RS
 This switch allows any of xosview's resources to be set on the command line.
 An example of how the xosview*memFreeColor could be set using this option is
-shown below (Note the use of " to prevent the shell from expanding
-\'*\' or from creating two separate arguments, \'xosview*memfreeColor:\'
-and \'purple\'):
+shown below. Note the use of quoting to prevent the shell from expanding '*'
+or from creating two separate arguments, 'xosview*memfreeColor:'
+and 'purple'):
 .RS
 \-xrm "xosview*memFreeColor: purple"
 .RE


### PR DESCRIPTION
Previously they were actually accents, picked up by Debian's Lintian:

I: xosview: acute-accent-in-manual-page usr/share/man/man1/xosview.1.gz:327
I: xosview: acute-accent-in-manual-page usr/share/man/man1/xosview.1.gz:328

More details: https://lintian.debian.org/tags/acute-accent-in-manual-page.html

Reported-by: Kartik Mistry <kartik.mistry@gmail.com>
GitHub: #17